### PR TITLE
Add `getrandom` primitive for Linux

### DIFF
--- a/src/SecureRandom.savi
+++ b/src/SecureRandom.savi
@@ -71,7 +71,10 @@
     @_buffer.resize_possibly_including_uninitialized_memory(@_chunk)
 
     (@_limit / @_chunk).times -> (i |
-      _FFI.getentropy(@_buffer.cpointer(i * @_chunk), @_chunk)
+      case (
+      | Platform.is_macos | _FFI.getentropy(@_buffer.cpointer(i * @_chunk), @_chunk)
+      | Platform.is_linux | _FFI.getrandom(@_buffer.cpointer(i * @_chunk), @_chunk)
+      )
     )
 
     @_offset = 0

--- a/src/_FFI.savi
+++ b/src/_FFI.savi
@@ -1,3 +1,7 @@
 :module _FFI
+  // MacOS
   :ffi getentropy(buffer CPointer(U8), size USize) I32
+
+  // Linux
+  :ffi getrandom(buffer CPointer(U8), size USize) I32
 


### PR DESCRIPTION
This PR adds a `getrandom` FFI function to support Linux.

We can also use the `getrandom` for FreeBSD, but right now `Platform.is_bsd` doesn't differentiate between FreeBSD and OpenBSD, which uses `getentropy` according to the [Rust docs here](https://docs.rs/getrandom/latest/getrandom/). Once we implement `Platform.is_freebsd`, and similar flavors, we'll circle back here to support them.