### PR TITLE
Fix Linux by looping `getrandom` until it succeeds.

### DIFF
--- a/src/SecureRandom.savi
+++ b/src/SecureRandom.savi
@@ -72,8 +72,15 @@
 
     (@_limit / @_chunk).times -> (i |
       case (
-      | Platform.is_macos | _FFI.getentropy(@_buffer.cpointer(i * @_chunk), @_chunk)
-      | Platform.is_linux | _FFI.getrandom(@_buffer.cpointer(i * @_chunk), @_chunk)
+      | Platform.is_macos |
+        _FFI.getentropy(@_buffer.cpointer(i * @_chunk), @_chunk)
+      | Platform.is_linux |
+        // Linux `getrandom` can sometimes fail when there isn't enough entropy.
+        // We'll just spin here until it succeeds, to avoid insecure output.
+        result = -1
+        while (result == -1) (
+          result = _FFI.getrandom(@_buffer.cpointer(i * @_chunk), @_chunk)
+        )
       )
     )
 


### PR DESCRIPTION
Linux `getrandom` can sometimes fail when there isn't enough entropy. We'll just spin here until it succeeds, to avoid insecure output.