### PR TITLE
Fix getrandom FFI signature and usage on Linux.

### DIFF
--- a/spec/SecureRandom.Spec.savi
+++ b/spec/SecureRandom.Spec.savi
@@ -26,4 +26,3 @@
     assert: random.u32 <: U32
     assert: random.u16 <: U16
     assert: random.u8  <: U8
-

--- a/src/SecureRandom.savi
+++ b/src/SecureRandom.savi
@@ -77,12 +77,7 @@
       | Platform.is_windows |
         _FFI.windows_getrandom(@_buffer.cpointer(i * @_chunk), @_chunk)
       | Platform.is_linux |
-        // Linux `getrandom` can sometimes fail when there isn't enough entropy.
-        // We'll just spin here until it succeeds, to avoid insecure output.
-        result = -1
-        while (result == -1) (
-          result = _FFI.getrandom(@_buffer.cpointer(i * @_chunk), @_chunk)
-        )
+        _FFI.getrandom(@_buffer.cpointer(i * @_chunk), @_chunk, 0)
       )
     )
 

--- a/src/_FFI.savi
+++ b/src/_FFI.savi
@@ -3,7 +3,7 @@
   :ffi getentropy(buffer CPointer(U8), size USize) I32
 
   // Linux
-  :ffi getrandom(buffer CPointer(U8), size USize) I32
+  :ffi getrandom(buffer CPointer(U8), size USize, flags U32) ISize
 
   // Windows
   :ffi _windowsBCryptGenRandom(


### PR DESCRIPTION
The prior usage and FFI signature were wrong.
Not sure how that code was ever working...